### PR TITLE
Append [Extension] to the log when AWS secrets initialization fails

### DIFF
--- a/extension/extension.go
+++ b/extension/extension.go
@@ -109,7 +109,7 @@ func populateSecrets(config *Config) {
 
 	awsSecretsManager, err := secrets.New()
 	if err != nil {
-		log.Errorf("unable to initiliaze AWSSecrets: %v", err)
+		log.Errorf("[Extension] Unable to initiliaze AWSSecrets: %v", err)
 	}
 
 	for i := range config.SecretManagers {

--- a/extension/extension.go
+++ b/extension/extension.go
@@ -109,7 +109,7 @@ func populateSecrets(config *Config) {
 
 	awsSecretsManager, err := secrets.New()
 	if err != nil {
-		log.Errorf("[Extension] Unable to initiliaze AWSSecrets: %v", err)
+		log.Errorf("[Extension] Unable to initialize AWSSecrets: %v", err)
 	}
 
 	for i := range config.SecretManagers {


### PR DESCRIPTION
Thanks for the an awesome [blog post](https://developer.squareup.com/blog/using-aws-lambda-extensions-to-accelerate-aws-secrets-manager-access/).

The following paragraph was taken from the blog post:
> Logs from the extension, other layers, and function are sent to the same CloudWatch Log Stream. We appended [extension] to all of the logs for our extension so we could easily tell where the log line came from.

This PR appends `[Extension]` to the log when AWS secrets initialization fails in the extension and fix typo as well.