### PR TITLE
Update branch name in Github Actions Workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: Go
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
 


### PR DESCRIPTION
Starting from October Github defaults to use `main` branch name instead of `master`. This PR updates the workflow to use `main` branch. 

Currently, the workflow is not triggered during push or pull_request event and this PR fixes that. 

**Test:**
- [x] The workflow should be triggered for this pull request.